### PR TITLE
Get correct microtime from date.

### DIFF
--- a/src/AvaTax/GetTaxRequest.php
+++ b/src/AvaTax/GetTaxRequest.php
@@ -40,11 +40,12 @@ class GetTaxRequest
 
 	public function __construct()
 	{
-		$this->DocDate = date("Y-m-d");
+		$date = \DateTime::createFromFormat('U.u', microtime(true));
+		$this->DocDate = $date->format('Y-m-d');
 		$this->Commit=false;
 		$this->DocType=DocumentType::$SalesOrder;
 		$this->DetailLevel=DetailLevel::$Tax;
-		$this->DocCode = date("Y-m-d-H-i-s.u");
+		$this->DocCode = $date->format('Y-m-d-H-i-s.u');
 		$this->CustomerCode='CustomerCodeString';
 		$this->Lines=array(new Line());							
 	}


### PR DESCRIPTION
```Microseconds (added in PHP 5.2.2). Note that date() will always generate 000000 since it takes an integer parameter, whereas DateTime::format() does support microseconds if DateTime was created with microseconds.```

http://php.net/manual/en/function.date.php