### PR TITLE
declare a file for namespaced exception class, and use it

### DIFF
--- a/src/AvaTax/AddressServiceRest.php
+++ b/src/AvaTax/AddressServiceRest.php
@@ -21,7 +21,6 @@
  */
 
 namespace AvaTax;
-class Exception extends \Exception {}
 
 class AddressServiceRest 
 {
@@ -50,8 +49,8 @@ class AddressServiceRest
 	public function validate($validateRequest)
 	{
 		if(!(filter_var($this->config['url'],FILTER_VALIDATE_URL)))			throw new \Exception("A valid service URL is required.");
-		if(empty($this->config['account']))		throw new \Exception("Account number or username is required.");
-		if(empty($this->config['license']))		throw new \Exception("License key or password is required.");
+		if(empty($this->config['account']))		throw new Exception("Account number or username is required.");
+		if(empty($this->config['license']))		throw new Exception("License key or password is required.");
 
 		$url =  $this->config['url'].'/1.0/address/validate?'. http_build_query($validateRequest->getAddress());
 		$curl = curl_init();

--- a/src/AvaTax/Exception.php
+++ b/src/AvaTax/Exception.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace AvaTax;
+
+class Exception extends \Exception
+{}

--- a/src/AvaTax/TaxServiceRest.php
+++ b/src/AvaTax/TaxServiceRest.php
@@ -20,7 +20,6 @@
  */
 
 namespace AvaTax;
-class Exception extends \Exception {}
 
 class TaxServiceRest
 {
@@ -54,8 +53,8 @@ class TaxServiceRest
 	public function cancelTax(&$cancelTaxRequest)
 	{
 		if(!(filter_var($this->config['url'],FILTER_VALIDATE_URL)))			throw new \Exception("A valid service URL is required.");
-		if(empty($this->config['account']))		throw new \Exception("Account number or username is required.");
-		if(empty($this->config['license']))		throw new \Exception("License key or password is required.");
+		if(empty($this->config['account']))		throw new Exception("Account number or username is required.");
+		if(empty($this->config['license']))		throw new Exception("License key or password is required.");
 		
 		$url = $this->config['url']."/1.0/tax/cancel";
 		$curl = curl_init($url);
@@ -83,8 +82,8 @@ class TaxServiceRest
 	public function getTax(&$getTaxRequest)
 		{
 		if(!(filter_var($this->config['url'],FILTER_VALIDATE_URL)))			throw new \Exception("A valid service URL is required.");
-		if(empty($this->config['account']))		throw new \Exception("Account number or username is required.");
-		if(empty($this->config['license']))		throw new \Exception("License key or password is required.");
+		if(empty($this->config['account']))		throw new Exception("Account number or username is required.");
+		if(empty($this->config['license']))		throw new Exception("License key or password is required.");
 
 		$url = $this->config['url']."/1.0/tax/get";
 		$curl = curl_init($url);
@@ -116,8 +115,8 @@ class TaxServiceRest
 	public function estimateTax(&$estimateTaxRequest)
 	{
 		if(!(filter_var($this->config['url'],FILTER_VALIDATE_URL)))			throw new \Exception("A valid service URL is required.");
-		if(empty($this->config['account']))		throw new \Exception("Account number or username is required.");
-		if(empty($this->config['license']))		throw new \Exception("License key or password is required.");
+		if(empty($this->config['account']))		throw new Exception("Account number or username is required.");
+		if(empty($this->config['license']))		throw new Exception("License key or password is required.");
 
 		$url =  $this->config['url'].'/1.0/tax/'. $estimateTaxRequest->getLatitude().",".$estimateTaxRequest->getLongitude().'/get?saleamount='.$estimateTaxRequest->getSaleAmount();
 		$curl = curl_init();


### PR DESCRIPTION
Recent change to throwing of `Exception` instances declare a local class, but then use the unnamespaced, generic `Exception` class.  The local declarations create ambiguity when using composer with the project.

This change creates a separate file for the namespaced `Exception` class, and makes use of it.