### PR TITLE
GetTaxResult properties json encode

### DIFF
--- a/src/AvaTax/GetTaxResult.php
+++ b/src/AvaTax/GetTaxResult.php
@@ -100,7 +100,15 @@ class GetTaxResult implements JsonSerializable// extends BaseResult
 		$taxdate, $taxlines, $taxsummary, $taxaddresses );	
 	}
 
-	public function jsonSerialize(){
+	public function jsonSerialize()
+    {
+        $taxLines = array_map(
+            function ($line) {
+                return $line->jsonSerialize();
+            },
+            $this->getTaxLines()
+        );
+
 		return array(
 			'DocCode' =>  $this->getDocCode(), 
 			'DocDate' =>  $this->getDocDate(),			 				
@@ -112,7 +120,7 @@ class GetTaxResult implements JsonSerializable// extends BaseResult
 			'TotalTax' =>  $this->getTotalTax(),		  	
 			'TotalTaxCalculated' =>  $this->getTotalTaxCalculated(),		 
 			'TaxDate' =>  $this->getTaxDate(),		
-		 	'TaxLines' =>  $this->getTaxLines(),	
+		 	'TaxLines' =>  $taxLines,
 			'TaxSummary' =>  $this->getTaxSummary(),		
 			'TaxAddresses' =>  $this->getTaxAddresses(),
 			'ResultCode'=> $this->getResultCode(),

--- a/src/AvaTax/GetTaxResult.php
+++ b/src/AvaTax/GetTaxResult.php
@@ -100,22 +100,11 @@ class GetTaxResult implements JsonSerializable// extends BaseResult
 		$taxdate, $taxlines, $taxsummary, $taxaddresses );	
 	}
 
+    /**
+     * @return array
+     */
 	public function jsonSerialize()
     {
-        $taxLines = array_map(
-            function ($line) {
-                return $line->jsonSerialize();
-            },
-            $this->getTaxLines()
-        );
-
-        $messages = array_map(
-            function ($line) {
-                return $line->jsonSerialize();
-            },
-            $this->getMessages()
-        );
-
 		return array(
 			'DocCode' =>  $this->getDocCode(), 
 			'DocDate' =>  $this->getDocDate(),			 				
@@ -126,14 +115,28 @@ class GetTaxResult implements JsonSerializable// extends BaseResult
 			'TotalTaxable' =>  $this->getTotalTaxable(),	 
 			'TotalTax' =>  $this->getTotalTax(),		  	
 			'TotalTaxCalculated' =>  $this->getTotalTaxCalculated(),		 
-			'TaxDate' =>  $this->getTaxDate(),		
-		 	'TaxLines' =>  $taxLines,
-			'TaxSummary' =>  $this->getTaxSummary(),		
+			'TaxDate' =>  $this->getTaxDate(),
+            'TaxLines' =>  $this->jsonSerializeArray($this->getTaxLines()),
+			'TaxSummary' =>  $this->getTaxSummary(),
 			'TaxAddresses' =>  $this->getTaxAddresses(),
 			'ResultCode'=> $this->getResultCode(),
-			'Messages' => $messages
+			'Messages' => $this->jsonSerializeArray($this->getMessages()),
 		);
 	}
+
+    /**
+     * @param array $items
+     * @return array
+     */
+    private function jsonSerializeArray(array $items)
+    {
+        return array_map(
+            function ($item) {
+                return $item->jsonSerialize();
+            },
+            $items
+        );
+    }
 
 	public function getDocCode() { return $this->DocCode; } 
 	public function getDocDate() { return $this->DocDate; }			 				

--- a/src/AvaTax/GetTaxResult.php
+++ b/src/AvaTax/GetTaxResult.php
@@ -109,6 +109,13 @@ class GetTaxResult implements JsonSerializable// extends BaseResult
             $this->getTaxLines()
         );
 
+        $messages = array_map(
+            function ($line) {
+                return $line->jsonSerialize();
+            },
+            $this->getMessages()
+        );
+
 		return array(
 			'DocCode' =>  $this->getDocCode(), 
 			'DocDate' =>  $this->getDocDate(),			 				
@@ -124,7 +131,7 @@ class GetTaxResult implements JsonSerializable// extends BaseResult
 			'TaxSummary' =>  $this->getTaxSummary(),		
 			'TaxAddresses' =>  $this->getTaxAddresses(),
 			'ResultCode'=> $this->getResultCode(),
-			'Messages' => $this->getMessages()
+			'Messages' => $messages
 		);
 	}
 

--- a/src/AvaTax/GetTaxResult.php
+++ b/src/AvaTax/GetTaxResult.php
@@ -117,7 +117,7 @@ class GetTaxResult implements JsonSerializable// extends BaseResult
 			'TotalTaxCalculated' =>  $this->getTotalTaxCalculated(),		 
 			'TaxDate' =>  $this->getTaxDate(),
             'TaxLines' =>  $this->jsonSerializeArray($this->getTaxLines()),
-			'TaxSummary' =>  $this->getTaxSummary(),
+			'TaxSummary' =>  $this->jsonSerializeArray($this->getTaxSummary()),
 			'TaxAddresses' =>  $this->getTaxAddresses(),
 			'ResultCode'=> $this->getResultCode(),
 			'Messages' => $this->jsonSerializeArray($this->getMessages()),

--- a/src/AvaTax/TaxLine.php
+++ b/src/AvaTax/TaxLine.php
@@ -84,8 +84,16 @@ class TaxLine implements JsonSerializable
 		return $lineArray;
 	}
 	public function jsonSerialize(){
+
+        $taxDetails = array_map(
+            function ($detail) {
+                return $detail->jsonSerialize();
+            },
+            $this->getTaxDetails()
+        );
+
 		return array(
-			'TaxDetails' => $this->getTaxDetails(),
+			'TaxDetails' => $taxDetails,
 			'LineNo' => $this->getLineNo(),
 			'TaxCode' => $this->getTaxCode(),
 			'Taxability' => $this->getTaxability(),


### PR DESCRIPTION
When you execute  `json_encode(GetTaxResult)`you get a json similar to:

```
{
    "DocCode": "DOCCODE01",
    "DocDate": "2016-02-11",
    "Timestamp": "2016-02-11T15:52:58.2634494Z",
    "TotalAmount": "143.5",
    "TotalDiscount": "0",
    "TotalExemption": "0",
    "TotalTaxable": "143.5",
    "TotalTax": "30.14",
    "TotalTaxCalculated": "30.14",
    "TaxDate": "2016-02-11",
    "TaxLines": [
        [],
        []
    ],
    "TaxSummary": [],
    "TaxAddresses": {
        "AddressCode": null,
        "Line1": null,
        "Line2": null,
        "Line3": null,
        "City": null,
        "Region": null,
        "PostalCode": null,
        "Country": null,
        "TaxRegionId": null,
        "Latitude": null,
        "Longitude": null
    },
    "ResultCode": "Success",
    "Messages": []
}
```

As you can notice, neither `TaxLines` (with their `TaxDetails`) nor `Messages` are correctly serialized.

Applying this change we could get a more complete serialization, something similar to:

```
{
    "DocCode": "DOCCODE01",
    "DocDate": "2016-02-11",
    "Timestamp": "2016-02-15T09:55:45.5684464Z",
    "TotalAmount": "143.5",
    "TotalDiscount": "0",
    "TotalExemption": "0",
    "TotalTaxable": "143.5",
    "TotalTax": "30.14",
    "TotalTaxCalculated": "30.14",
    "TaxDate": "2016-02-11",
    "TaxLines": [
        {
            "TaxDetails": [
                {
                    "JurisType": "Country",
                    "Taxable": 127.52380952381,
                    "Rate": "0.210000",
                    "Tax": "26.78",
                    "JurisName": "SPAIN",
                    "TaxName": "Standard Rate",
                    "Country": "ES",
                    "Region": "ES"
                }
            ],
            "LineNo": "1",
            "TaxCode": "P0000000",
            "Taxability": "true",
            "BoundaryLevel": "Zip5",
            "Exemption": "0",
            "Discount": "0",
            "Taxable": "127.5",
            "Rate": "0.210000",
            "Tax": "26.78",
            "TaxCalculated": "26.78"
        },
        {
            "TaxDetails": [
                {
                    "JurisType": "Country",
                    "Taxable": 16,
                    "Rate": "0.210000",
                    "Tax": "3.36",
                    "JurisName": "SPAIN",
                    "TaxName": "Standard Rate",
                    "Country": "ES",
                    "Region": "ES"
                }
            ],
            "LineNo": "2",
            "TaxCode": "P0000000",
            "Taxability": "true",
            "BoundaryLevel": "Zip5",
            "Exemption": "0",
            "Discount": "0",
            "Taxable": "16",
            "Rate": "0.210000",
            "Tax": "3.36",
            "TaxCalculated": "3.36"
        }
    ],
    "TaxSummary": [],
    "TaxAddresses": {
        "AddressCode": null,
        "Line1": null,
        "Line2": null,
        "Line3": null,
        "City": null,
        "Region": null,
        "PostalCode": null,
        "Country": null,
        "TaxRegionId": null,
        "Latitude": null,
        "Longitude": null
    },
    "ResultCode": "Success",
    "Messages": []
}
```
