### PR TITLE
Fix for TaxDetail not being parsed when Summary is used.

### DIFF
--- a/src/AvaTax/TaxDetail.php
+++ b/src/AvaTax/TaxDetail.php
@@ -57,8 +57,9 @@ class TaxDetail implements JsonSerializable
 	{
 		$object = json_decode($jsonString);
 		$detailArray = array();
+		$details = isset($object->TaxDetails) ? $object->TaxDetails : $object->TaxSummary;
 
-		foreach($object->TaxDetails as $detail)
+		foreach($details as $detail)
 		{
 		$taxable = 0;
 		if ($detail->Rate != 0) {


### PR DESCRIPTION
If you use a DetailLevel of Summary you'll get this error:
Undefined property: stdClass::$TaxDetails