### PR TITLE
32 error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,8 @@ Samples/composer.json
 Samples/vendor/
 Samples/composer.lock
 vendor/
+
+############
+## PHPStorm
+############
+.idea

--- a/src/AvaTax/Address.php
+++ b/src/AvaTax/Address.php
@@ -33,7 +33,6 @@ namespace AvaTax;
  
 class Address
 {
-
 	public $AddressCode;
 	public $Line1;
 	public $Line2;

--- a/src/AvaTax/AddressServiceRest.php
+++ b/src/AvaTax/AddressServiceRest.php
@@ -2,9 +2,9 @@
 /**
  * AddressServiceRest.class.php
  */
- 
+
 /**
- * Interface for the Avalara Address Web Service. 
+ * Interface for the Avalara Address Web Service.
  *
  * AddressServiceRest reads its configuration values from parameters in the constructor
  *
@@ -17,12 +17,12 @@
  * @author    Avalara
  * @copyright � 2004 - 2011 Avalara, Inc.  All rights reserved.
  * @package   Address
- * 
+ *
  */
 
 namespace AvaTax;
 
-class AddressServiceRest 
+class AddressServiceRest
 {
 	static protected $classmap = array(
 		'Validate' => 'Validate',
@@ -45,7 +45,7 @@ class AddressServiceRest
 	}
 
 
-		//Validates/normalizes a single provided address. Will either return a single, non-ambiguous validated address match or an error.
+	//Validates/normalizes a single provided address. Will either return a single, non-ambiguous validated address match or an error.
 	public function validate($validateRequest)
 	{
 		if(!(filter_var($this->config['url'], FILTER_VALIDATE_URL))) {

--- a/src/AvaTax/AddressServiceRest.php
+++ b/src/AvaTax/AddressServiceRest.php
@@ -22,7 +22,7 @@
 
 namespace AvaTax;
 
-class AddressServiceRest
+class AddressServiceRest extends RestService
 {
 	static protected $classmap = array(
 		'Validate' => 'Validate',
@@ -33,89 +33,6 @@ class AddressServiceRest
 		'BaseResult' => 'BaseResult',
 		'SeverityLevel' => 'SeverityLevel',
 		'Message' => 'Message');
-
-	protected $config = array();
-
-	/**
-	 * AddressServiceRest constructor.
-	 *
-	 * @param $url string - domain for API endpoint
-	 * @param $account string - API account
-	 * @param $license string - API license
-	 * @param bool $ssl - whether to use SSL connecting to the API (Windows users read below)
-	 * Some Windows users have had trouble with our SSL Certificates. Uncomment the following line to NOT use SSL.
-	 * This is not recommended, see below ($ssl_ca_path) for better alternative*
-	 * @param null $ssl_ca_path - Manually set an SSL path to a cert (Windows users read below)
-	 * $ssl_ca_path: Other Windows users may prefer to download the certificate from our site (detail here: http://developer.avalara.com/api-docs/designing-your-integration/errors-and-outages/ssl-certificates) and manually set the cert path.
-	 * To set the path manually, uncomment the following two lines and ensure you are telling curl where it can find the root certificate. If you choose to manually set the path, make sure you have reenabled cURL by commenting out the line above
-	 * that tells curl to NOT use SSL.
-	 * ex: $ssl_ca_path = "C:/curl/curl-ca-bundle.crt";
-	 *
-	 */
-	public function __construct($url, $account, $license, $ssl = true, $ssl_ca_path = null)
-	{
-		$this->config = array(
-			'url' => $url,
-			'account' => $account,
-			'license' => $license,
-			'ssl' => $ssl,
-			'ssl_ca_path' => $ssl_ca_path
-		);
-	}
-
-	/**
-	 * Send a request to the API endpoint
-	 *
-	 * @param $path
-	 * @param null $data
-	 * @return mixed
-	 * @throws AvaException
-	 */
-	private function processRequest($path, $data = null)
-	{
-		if(!$this->config['url'] || !(filter_var($this->config['url'], FILTER_VALIDATE_URL))) {
-			throw new AvaException("A valid service URL is required.", AvaException::MISSING_INFO);
-		}
-
-		if(empty($this->config['account'])) {
-			throw new AvaException("Account number or username is required.", AvaException::MISSING_INFO);
-		}
-
-		if(empty($this->config['license'])) {
-			throw new AvaException("License key or password is required.", AvaException::MISSING_INFO);
-		}
-
-		$curl = curl_init();
-		curl_setopt($curl, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
-		curl_setopt($curl, CURLOPT_USERPWD, $this->config['account'].":".$this->config['license']);
-		curl_setopt($curl, CURLOPT_URL, $this->config['url'].$path);
-		curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-		curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, $this->config['ssl']);
-
-		if($this->config['ssl_ca_path']) {
-			curl_setopt($curl, CURLOPT_CAINFO, $this->config['ssl_ca_path']);
-		}
-
-		if($data) {
-			curl_setopt($curl, CURLOPT_POST, true);
-			curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($data));
-		}
-
-		$response = curl_exec($curl);
-
-		if($error_number = curl_errno($curl)) {
-			$error_msg = curl_strerror($error_number);
-			throw new AvaException("AddressServiceRest cURL error ({$error_number}): {$error_msg}", AvaException::CURL_ERROR);
-		}
-
-		if(!$response) {
-			throw new AvaException('AddressServiceRest received empty result from API', AvaException::INVALID_API_RESPONSE);
-		}
-
-		curl_close($curl);
-
-		return $response;
-	}
 
 	/**
 	 * Validates/normalizes a single provided address. Will either return a single, non-ambiguous validated address match or an error.

--- a/src/AvaTax/AddressServiceRest.php
+++ b/src/AvaTax/AddressServiceRest.php
@@ -36,51 +36,98 @@ class AddressServiceRest
 
 	protected $config = array();
 
-	public function __construct($url, $account, $license)
+	/**
+	 * AddressServiceRest constructor.
+	 *
+	 * @param $url string - domain for API endpoint
+	 * @param $account string - API account
+	 * @param $license string - API license
+	 * @param bool $ssl - whether to use SSL connecting to the API (Windows users read below)
+	 * Some Windows users have had trouble with our SSL Certificates. Uncomment the following line to NOT use SSL.
+	 * This is not recommended, see below ($ssl_ca_path) for better alternative*
+	 * @param null $ssl_ca_path - Manually set an SSL path to a cert (Windows users read below)
+	 * $ssl_ca_path: Other Windows users may prefer to download the certificate from our site (detail here: http://developer.avalara.com/api-docs/designing-your-integration/errors-and-outages/ssl-certificates) and manually set the cert path.
+	 * To set the path manually, uncomment the following two lines and ensure you are telling curl where it can find the root certificate. If you choose to manually set the path, make sure you have reenabled cURL by commenting out the line above
+	 * that tells curl to NOT use SSL.
+	 * ex: $ssl_ca_path = "C:/curl/curl-ca-bundle.crt";
+	 *
+	 */
+	public function __construct($url, $account, $license, $ssl = true, $ssl_ca_path = null)
 	{
 		$this->config = array(
 			'url' => $url,
 			'account' => $account,
-			'license' => $license);
+			'license' => $license,
+			'ssl' => $ssl,
+			'ssl_ca_path' => $ssl_ca_path
+		);
 	}
 
-
-	//Validates/normalizes a single provided address. Will either return a single, non-ambiguous validated address match or an error.
-	public function validate($validateRequest)
+	/**
+	 * Send a request to the API endpoint
+	 *
+	 * @param $path
+	 * @param null $data
+	 * @return mixed
+	 * @throws AvaException
+	 */
+	private function processRequest($path, $data = null)
 	{
-		if(!(filter_var($this->config['url'], FILTER_VALIDATE_URL))) {
+		if(!$this->config['url'] || !(filter_var($this->config['url'], FILTER_VALIDATE_URL))) {
 			throw new AvaException("A valid service URL is required.", AvaException::MISSING_INFO);
 		}
 
-		if(empty($this->config['account'])){
+		if(empty($this->config['account'])) {
 			throw new AvaException("Account number or username is required.", AvaException::MISSING_INFO);
 		}
 
-		if(empty($this->config['license'])){
+		if(empty($this->config['license'])) {
 			throw new AvaException("License key or password is required.", AvaException::MISSING_INFO);
 		}
 
-		$url =  $this->config['url'].'/1.0/address/validate?'. http_build_query($validateRequest->getAddress());
 		$curl = curl_init();
 		curl_setopt($curl, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
-		//curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false); //Some Windows users have had trouble with our SSL Certificates. Uncomment this line to NOT use SSL.
 		curl_setopt($curl, CURLOPT_USERPWD, $this->config['account'].":".$this->config['license']);
-		curl_setopt($curl, CURLOPT_URL, $url);
-		curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
+		curl_setopt($curl, CURLOPT_URL, $this->config['url'].$path);
+		curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+		curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, $this->config['ssl']);
 
-		$result = curl_exec($curl);
+		if($this->config['ssl_ca_path']) {
+			curl_setopt($curl, CURLOPT_CAINFO, $this->config['ssl_ca_path']);
+		}
+
+		if($data) {
+			curl_setopt($curl, CURLOPT_POST, true);
+			curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($data));
+		}
+
+		$response = curl_exec($curl);
 
 		if($error_number = curl_errno($curl)) {
 			$error_msg = curl_strerror($error_number);
 			throw new AvaException("AddressServiceRest cURL error ({$error_number}): {$error_msg}", AvaException::CURL_ERROR);
 		}
 
-		if(!$result) {
+		if(!$response) {
 			throw new AvaException('AddressServiceRest received empty result from API', AvaException::INVALID_API_RESPONSE);
 		}
 
-		return ValidateResult::parseResult($result);
+		curl_close($curl);
 
+		return $response;
+	}
+
+	/**
+	 * Validates/normalizes a single provided address. Will either return a single, non-ambiguous validated address match or an error.
+	 *
+	 * @param ValidateRequest $validateRequest
+	 * @return ValidateResult
+	 * @throws AvaException
+	 */
+	public function validate(ValidateRequest $validateRequest)
+	{
+		$result = $this->processRequest('/1.0/address/validate?'. http_build_query($validateRequest->getAddress()));
+		return ValidateResult::parseResult($result);
 	}
 }
 ?>

--- a/src/AvaTax/AvaException.php
+++ b/src/AvaTax/AvaException.php
@@ -4,7 +4,13 @@ namespace AvaTax;
 
 class AvaException extends \Exception
 {
-    const INVALID_API_RESPONSE = 'invalid_response';
-    const CURL_ERROR = 'curl_error';
-    const MISSING_INFO = 'missing_info';
+    const UNKNOWN = 0;
+    const INVALID_API_RESPONSE = 1;
+    const CURL_ERROR = 2;
+    const MISSING_INFO = 3;
+
+    public function __construct($message = "", $code = self::UNKNOWN, \Exception $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
 }

--- a/src/AvaTax/AvaException.php
+++ b/src/AvaTax/AvaException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace AvaTax;
+
+class AvaException extends \Exception
+{
+    const INVALID_API_RESPONSE = 'invalid_response';
+    const CURL_ERROR = 'curl_error';
+    const MISSING_INFO = 'missing_info';
+}

--- a/src/AvaTax/AvaFunctions.php
+++ b/src/AvaTax/AvaFunctions.php
@@ -28,14 +28,14 @@ class AvaFunctions
 
 	public static function getDefaultDate()
 	{
-		$dateTime=new DateTime();
+		$dateTime = new \DateTime();
 		$dateTime->setDate(1900,01,01);
 		return $dateTime->format("Y-m-d");
 	}
 
 	public static function getCurrentDate()
 	{
-		$dateTime=new DateTime();
+		$dateTime = new \DateTime();
 		return $dateTime->format("Y-m-d");
 	} 
 }

--- a/src/AvaTax/AvaResult.php
+++ b/src/AvaTax/AvaResult.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace AvaTax;
+
+
+class AvaResult extends BaseResult
+{
+    /**
+     * Shortcut to decode and validate json
+     *
+     * @param $jsonString
+     * @return mixed
+     * @throws AvaException
+     */
+    public static function jsonDecode($jsonString)
+    {
+        $object = json_decode($jsonString);
+
+        if(json_last_error() !== JSON_ERROR_NONE) {
+            throw new AvaException('AvaResult: Error decoding JSON', AvaException::INVALID_API_RESPONSE);
+        }
+
+        if(!is_object($object)) {
+            throw new AvaException('AvaResult: Expected object from json_decode', AvaException::INVALID_API_RESPONSE);
+        }
+
+        return $object;
+    }
+}

--- a/src/AvaTax/BaseResult.php
+++ b/src/AvaTax/BaseResult.php
@@ -15,6 +15,12 @@ namespace AvaTax;
 
 class BaseResult implements JsonSerializable
 {
+    /** @var string */
+    protected $TransactionId;
+    /** @var string */
+    protected $ResultCode = 'Success';
+    /** @var array|Message[] */
+    protected $Messages = array();
 
 	public function jsonSerialize(){
 		return array(
@@ -24,22 +30,23 @@ class BaseResult implements JsonSerializable
 		);
 	}
 
-/**
- * A unique Transaction ID identifying a specific request/response set. Deprecated.
- * @return string
- */
+    /**
+     * A unique Transaction ID identifying a specific request/response set. Deprecated.
+     * @return string
+     */
 	public function getTransactionId() { return $this->TransactionId; }
-/**
- * Indicates whether operation was successfully completed or not.
- * @return string
- */
-	public function getResultCode() { return $this->ResultCode; }
-/**
- * Accessor
- * @return array
- */
-	public function getMessages() { return AvaFunctions::EnsureIsArray($this->Messages->Message); }
 
+    /**
+     * Indicates whether operation was successfully completed or not.
+     * @return string
+     */
+	public function getResultCode() { return $this->ResultCode; }
+
+    /**
+     * Accessor
+     * @return array
+     */
+	public function getMessages() { return AvaFunctions::EnsureIsArray($this->Messages); }
 }
 
 ?>

--- a/src/AvaTax/CancelTaxResult.php
+++ b/src/AvaTax/CancelTaxResult.php
@@ -14,15 +14,10 @@ namespace AvaTax;
  * 
  */
 
-class CancelTaxResult implements JsonSerializable
+class CancelTaxResult extends AvaResult implements JsonSerializable
 {
-
-
-	private $DocId; //Internal Avalara reference to document - may not be returned for some accounts
-	private $TransactionId; //Internal Avalara reference to server transaction - may not be returned for some accounts
-	private $ResultCode = 'Success'; //string, must be one of the values defined in {@link SeverityLevel}.
-	private $Messages = array(); //array of Message.
-
+    /** @var string Internal Avalara reference to document - may not be returned for some accounts */
+	private $DocId;
 
 	public function __construct($docId, $transactionId, $resultCode, $messages)
 	{
@@ -32,22 +27,42 @@ class CancelTaxResult implements JsonSerializable
 		$this->Messages = $messages;
 	}
 
-	//Helper function to decode result objects from Json responses to specific objects.
-	public function parseResult($jsonString)
+    /**
+     * Helper function to decode result objects from Json responses to specific objects.
+     *
+     * @param $jsonString
+     * @return CancelTaxResult
+     */
+	public static function parseResult($jsonString)
 	{
-		$object = json_decode($jsonString);
-		if(property_exists($object,"CancelTaxResult")) $object = $object->CancelTaxResult;
-		$messages = array();
-		$docid= null;
-		$transactionid= null;
-		$resultcode= null;
-		if(property_exists($object, "Messages"))
-			$messages = Message::parseMessages("{\"Messages\": ".json_encode($object->Messages)."}");
+        $object = self::jsonDecode($jsonString);
 
-		if(property_exists($object, "DocId")) $docid = $object->DocId;
-		if(property_exists($object, "TransactionId"))	$transactionid = $object->TransactionId;
-		if(property_exists($object, "ResultCode")) $resultcode = $object->ResultCode;
-		return new self($docid, $transactionid, $resultcode , $messages );
+		if(property_exists($object,"CancelTaxResult")) {
+		    $object = $object->CancelTaxResult;
+        }
+
+		$messages = array();
+		$docid = null;
+		$transactionid = null;
+		$resultcode = null;
+
+		if(property_exists($object, "Messages")) {
+		    $messages = Message::parseMessages("{\"Messages\": ".json_encode($object->Messages)."}");
+        }
+
+		if(property_exists($object, "DocId")) {
+		    $docid = $object->DocId;
+        }
+
+		if(property_exists($object, "TransactionId")) {
+		    $transactionid = $object->TransactionId;
+        }
+
+		if(property_exists($object, "ResultCode")) {
+		    $resultcode = $object->ResultCode;
+        }
+
+		return new self($docid, $transactionid, $resultcode, $messages);
 	}
 
 	public function jsonSerialize(){
@@ -60,12 +75,6 @@ class CancelTaxResult implements JsonSerializable
 	}
 
 	public function getDocId() { return $this->DocId; }
-	public function getTransactionId() { return $this->TransactionId; }
-	public function getResultCode() { return $this->ResultCode; }
-	public function getMessages() { return $this->Messages; }
-
-
-
 }
 
 ?>

--- a/src/AvaTax/Enum.php
+++ b/src/AvaTax/Enum.php
@@ -15,18 +15,25 @@ namespace AvaTax;
 
 class Enum
 {
-	// Basic implementation - check and throw
-	protected static function __Validate($value,$values,$class=__CLASS__)
+    /**
+     * Basic implementation - check and throw
+     * @param $value
+     * @param $values
+     * @param string $class
+     * @return bool
+     * @throws AvaException
+     */
+	protected static function __Validate($value, $values, $class = __CLASS__)
 	{
-	foreach($values as $valid)
-	{
-		if($value == $valid)
-		{
-			return true;
-		}
-	}
+        foreach($values as $valid)
+        {
+            if($value == $valid)
+            {
+                return true;
+            }
+        }
 
-	throw new Exception('Invalid '.$class.' "'.$value.'" - must be one of "'.implode('"|"',$values).'"');
+        throw new AvaException('Invalid '.$class.' "'.$value.'" - must be one of "'.implode('"|"',$values).'"');
 	}
 }
 

--- a/src/AvaTax/EstimateTaxResult.php
+++ b/src/AvaTax/EstimateTaxResult.php
@@ -4,19 +4,19 @@ namespace AvaTax;
  * EstimateTaxResult.class.php
  */
 
-
-
-class EstimateTaxResult extends BaseResult implements JsonSerializable
-{
 /**
  * Returns composite rate and total tax for location, with an array of jurisdictional details.
+ *
+ * @class EstimateTaxResult
  */
+class EstimateTaxResult extends AvaResult implements JsonSerializable
+{
 	private $Rate;
 	private $Tax;
+    /** @var array|TaxDetail[] */
 	private $TaxDetails = array();
 
-
-	public function __construct($resultCode , $rate , $tax, $taxdetails, $messages)
+	public function __construct($resultCode, $rate, $tax, $taxdetails, $messages)
 	{
 		$this->ResultCode = $resultCode;
 		$this->TaxDetails = $taxdetails;
@@ -24,27 +24,44 @@ class EstimateTaxResult extends BaseResult implements JsonSerializable
 		$this->Tax = $tax;
 		$this->Messages = $messages;
 	}
-	
-	
-		//Helper function to decode result objects from Json responses to specific objects.
+
+    /**
+     * Helper function to decode result objects from Json responses to specific objects.
+     *
+     * @param $jsonString
+     * @return EstimateTaxResult
+     */
 	public static function parseResult($jsonString)
 	{
-		$object = json_decode($jsonString);
+        $object = self::jsonDecode($jsonString);
+
 		$taxdetails = array();
 		$messages = array();
 		$resultcode = null;
 		$rate = null;
 		$tax = null;
 
-		if( property_exists($object,"Rate")) $rate = $object->Rate; 
-		if( property_exists($object,"Tax")) $tax = $object->Tax; 		
-		if( property_exists($object,"ResultCode")) $resultcode = $object->ResultCode; 
-		if(property_exists($object, "TaxDetails"))
-			$taxdetails = TaxDetail::parseTaxDetails("{\"TaxDetails\": ".json_encode($object->TaxDetails)."}");		
-		if(property_exists($object, "Messages"))
-			$messages = Message::parseMessages("{\"Messages\": ".json_encode($object->Messages)."}");
+		if( property_exists($object,"Rate")) {
+		    $rate = $object->Rate;
+        }
 
-		return new self( $resultcode , $rate, $tax , $taxdetails, $messages );
+		if( property_exists($object,"Tax")) {
+		    $tax = $object->Tax;
+        }
+
+		if( property_exists($object,"ResultCode")) {
+		    $resultcode = $object->ResultCode;
+        }
+
+		if(property_exists($object, "TaxDetails")) {
+		    $taxdetails = TaxDetail::parseTaxDetails("{\"TaxDetails\": ".json_encode($object->TaxDetails)."}");
+        }
+
+		if(property_exists($object, "Messages")) {
+		    $messages = Message::parseMessages("{\"Messages\": ".json_encode($object->Messages)."}");
+        }
+
+		return new self($resultcode, $rate, $tax, $taxdetails, $messages);
 	}
 
 	public function jsonSerialize(){
@@ -57,48 +74,9 @@ class EstimateTaxResult extends BaseResult implements JsonSerializable
 		);
 	}
 
-/**
- * Method returning array of matching {@link ValidAddress}'s.
- * @return array
- */
-		public function getRate() { return $this->Rate; }
-		public function getTax() { return $this->Tax; }
-		public function getTaxDetails() { return $this->TaxDetails; }
-	
-	
-	
-	/**
- * @var string
- */
-		//private $TransactionId;
-/**
- * @var string must be one of the values defined in {@link SeverityLevel}.
- */
-		private $ResultCode = 'Success';
-/**
- * @var array of Message.
- */
-		private $Messages = array();
-
-/**
- * Accessor
- * @return string
- */
-		//public function getTransactionId() { return $this->TransactionId; }
-/**
- * Accessor
- * @return string
- */
-		public function getResultCode() { return $this->ResultCode; }
-/**
- * Accessor
- * @return array
- */
-		public function getMessages() { return $this->Messages; }
-
-		//@author:swetal
-
-
+    public function getRate() { return $this->Rate; }
+    public function getTax() { return $this->Tax; }
+    public function getTaxDetails() { return $this->TaxDetails; }
 }
 
 ?>

--- a/src/AvaTax/GetTaxResult.php
+++ b/src/AvaTax/GetTaxResult.php
@@ -15,9 +15,9 @@
 
 namespace AvaTax;
 
-class GetTaxResult implements JsonSerializable// extends BaseResult
+class GetTaxResult extends AvaResult implements JsonSerializable
 {
-	private $DocCode;	//string  
+	private $DocCode;	//string
 	private $DocDate;			//date  		 	
 	private $Timestamp;		//dateTime  	
 	private $TotalAmount;		//decimal  
@@ -31,8 +31,7 @@ class GetTaxResult implements JsonSerializable// extends BaseResult
 	private $TaxSummary;		//ArrayOfTaxDetail	
 	private $TaxAddresses;		//ArrayOfAddress
 	
-	public function __construct( $resultCode, $messages, $docCode, $docDate, $timestamp, $totalAmount, $totalDiscount, $totalExemption, $totalTaxable, $totalTax, $totalTaxCalculated, 
-			$taxDate, $taxLines, $taxSummary, $taxAddresses)
+	public function __construct($resultCode, $messages, $docCode, $docDate, $timestamp, $totalAmount, $totalDiscount, $totalExemption, $totalTaxable, $totalTax, $totalTaxCalculated, $taxDate, $taxLines, $taxSummary, $taxAddresses)
 	{
 		$this->ResultCode = $resultCode;
 		$this->Messages = $messages;
@@ -52,10 +51,16 @@ class GetTaxResult implements JsonSerializable// extends BaseResult
 	
 	}
 
-    //Helper function to decode result objects from Json responses to specific objects.	
+    /**
+     * Helper function to decode result objects from Json responses to specific objects.
+     *
+     * @param $jsonString
+     * @return GetTaxResult
+     */
 	public static function parseResult($jsonString)
 	{
-		$object = json_decode($jsonString);
+		$object = self::jsonDecode($jsonString);
+
 		$taxlines = array();
 		$taxsummary = array();
 		$taxaddresses = array();
@@ -72,32 +77,67 @@ class GetTaxResult implements JsonSerializable// extends BaseResult
 		$totaltaxcalculated= null;
 		$taxdate= null;
 
-		if( property_exists($object,"ResultCode")) $resultcode = $object->ResultCode; 		
-		if( property_exists($object,"DocCode")) $doccode = $object->DocCode; 
-		if( property_exists($object,"DocDate")) $docdate = $object->DocDate;			 				
-		if( property_exists($object,"Timestamp")) $timestamp = $object->Timestamp;			
-		if( property_exists($object,"TotalAmount")) $totalamount = $object->TotalAmount;		
-		if( property_exists($object,"TotalDiscount")) $totaldiscount = $object->TotalDiscount;	
-		if( property_exists($object,"TotalExemption")) $totalexemption = $object->TotalExemption;	
-		if( property_exists($object,"TotalTaxable")) $totaltaxable = $object->TotalTaxable;	 
-		if( property_exists($object,"TotalTax")) $totaltax = $object->TotalTax;		  	
-		if( property_exists($object,"TotalTaxCalculated")) $totaltaxcalculated = $object->TotalTaxCalculated;		 
-		if( property_exists($object,"TaxDate")) $taxdate = $object->TaxDate;		
+		if( property_exists($object,"ResultCode")) {
+		    $resultcode = $object->ResultCode;
+        }
 
+		if( property_exists($object,"DocCode")) {
+		    $doccode = $object->DocCode;
+        }
+
+		if( property_exists($object,"DocDate")) {
+		    $docdate = $object->DocDate;
+        }
+
+		if( property_exists($object,"Timestamp")) {
+		    $timestamp = $object->Timestamp;
+        }
+
+		if( property_exists($object,"TotalAmount")) {
+		    $totalamount = $object->TotalAmount;
+        }
+
+		if( property_exists($object,"TotalDiscount")) {
+            $totaldiscount = $object->TotalDiscount;
+        }
+
+		if( property_exists($object,"TotalExemption")) {
+            $totalexemption = $object->TotalExemption;
+        }
+
+		if( property_exists($object,"TotalTaxable")) {
+		    $totaltaxable = $object->TotalTaxable;
+        }
+
+		if( property_exists($object,"TotalTax")) {
+		    $totaltax = $object->TotalTax;
+        }
+
+		if( property_exists($object,"TotalTaxCalculated")) {
+		    $totaltaxcalculated = $object->TotalTaxCalculated;
+        }
+
+		if( property_exists($object,"TaxDate")) {
+		    $taxdate = $object->TaxDate;
+        }
+
+		if(property_exists($object, "TaxLines")) {
+		    $taxlines = TaxLine::parseTaxLines("{\"TaxLines\": ".json_encode($object->TaxLines)."}");
+        }
+
+		if(property_exists($object, "TaxSummary")) {
+		    $taxsummary = TaxDetail::parseTaxDetails("{\"TaxDetails\": ".json_encode($object->TaxSummary)."}");
+        }
+
+		if(property_exists($object, "TaxAddresses")) {
+		    $taxaddresses = Address::parseAddress("{\"TaxAddresses\": ".json_encode($object->TaxAddresses)."}");
+        }
+
+		if(property_exists($object, "Messages")) {
+		    $messages = Message::parseMessages("{\"Messages\": ".json_encode($object->Messages)."}");
+        }
 		
-		if(property_exists($object, "TaxLines"))
-			$taxlines = TaxLine::parseTaxLines("{\"TaxLines\": ".json_encode($object->TaxLines)."}");
-		if(property_exists($object, "TaxSummary"))
-			$taxsummary = TaxDetail::parseTaxDetails("{\"TaxDetails\": ".json_encode($object->TaxSummary)."}");
-		if(property_exists($object, "TaxAddresses"))
-			$taxaddresses = Address::parseAddress("{\"TaxAddresses\": ".json_encode($object->TaxAddresses)."}");	
-		if(property_exists($object, "Messages"))
-			$messages = Message::parseMessages("{\"Messages\": ".json_encode($object->Messages)."}");
-		
-		return new self( $resultcode , $messages, $doccode, $docdate, 
-		$timestamp, $totalamount, $totaldiscount,
-		$totalexemption, $totaltaxable, $totaltax, $totaltaxcalculated,
-		$taxdate, $taxlines, $taxsummary, $taxaddresses );	
+		return new self($resultcode , $messages, $doccode, $docdate, $timestamp, $totalamount, $totaldiscount, $totalexemption, $totaltaxable, $totaltax, $totaltaxcalculated, $taxdate, $taxlines, $taxsummary, $taxaddresses);
 	}
 
     /**
@@ -165,9 +205,13 @@ class GetTaxResult implements JsonSerializable// extends BaseResult
  	public function setTaxLines($value) {  $this->TaxLines= $value; }	
 	public function setTaxSummary($value) {  $this->TaxSummary= $value; }		
 	public function setTaxAddresses($value) {  $this->TaxAddresses= $value; }
-	
 
-	//Allows for direct reference to and lookup of lines by line number.
+    /**
+     * Allows for direct reference to and lookup of lines by line number.
+     *
+     * @param $lineNo
+     * @return mixed
+     */
 	public function getTaxLine($lineNo)
 	{
 		if($this->getTaxLines() != null)
@@ -178,39 +222,9 @@ class GetTaxResult implements JsonSerializable// extends BaseResult
 				{
 					return $taxLine;
 				}
-				
 			}
 		}
 	}
-			
-	
-			
-	/////////////////////////////////////////////PHP bug requires this copy from BaseResult ///////////
-	/**
-	* @var string must be one of the values defined in {@link SeverityLevel}.
-	*/
-    private $ResultCode = 'Success';
-	/**
-	* @var array of Message.
-	*/
-    private $Messages = array();
-
-	/**
-	* Accessor
-	* @return string
-	*/
-    public function getResultCode() { return $this->ResultCode; }
-	/**
-	* Accessor
-	* @return array
-	*/
-    public function getMessages() { return $this->Messages; }
-    
-    
-
-
-
-
 }
 
 ?>

--- a/src/AvaTax/RestService.php
+++ b/src/AvaTax/RestService.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace AvaTax;
+
+
+class RestService
+{
+    protected $config;
+
+    /**
+     * AddressServiceRest constructor.
+     *
+     * @param $url string - domain for API endpoint
+     * @param $account string - API account
+     * @param $license string - API license
+     * @param bool $ssl - whether to use SSL connecting to the API (Windows users read below)
+     * Some Windows users have had trouble with our SSL Certificates. Uncomment the following line to NOT use SSL.
+     * This is not recommended, see below ($ssl_ca_path) for better alternative*
+     * @param null $ssl_ca_path - Manually set an SSL path to a cert (Windows users read below)
+     * $ssl_ca_path: Other Windows users may prefer to download the certificate from our site (detail here: http://developer.avalara.com/api-docs/designing-your-integration/errors-and-outages/ssl-certificates) and manually set the cert path.
+     * To set the path manually, uncomment the following two lines and ensure you are telling curl where it can find the root certificate. If you choose to manually set the path, make sure you have reenabled cURL by commenting out the line above
+     * that tells curl to NOT use SSL.
+     * ex: $ssl_ca_path = "C:/curl/curl-ca-bundle.crt";
+     * @param null $curl_options
+     */
+    public function __construct($url, $account, $license, $ssl = true, $ssl_ca_path = null, $curl_options = null)
+    {
+        $this->config = array(
+            'url' => $url,
+            'account' => $account,
+            'license' => $license,
+            'ssl' => $ssl,
+            'ssl_ca_path' => $ssl_ca_path,
+            'curl_options' => $curl_options
+        );
+    }
+
+    /**
+     * Send a request to the API endpoint
+     *
+     * @param $path
+     * @param null $data
+     * @return mixed
+     * @throws AvaException
+     */
+    protected function processRequest($path, $data = null)
+    {
+        if(!$this->config['url'] || !(filter_var($this->config['url'], FILTER_VALIDATE_URL))) {
+            throw new AvaException("A valid service URL is required.", AvaException::MISSING_INFO);
+        }
+
+        if(empty($this->config['account'])) {
+            throw new AvaException("Account number or username is required.", AvaException::MISSING_INFO);
+        }
+
+        if(empty($this->config['license'])) {
+            throw new AvaException("License key or password is required.", AvaException::MISSING_INFO);
+        }
+
+        $curl = curl_init();
+        curl_setopt($curl, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+        curl_setopt($curl, CURLOPT_USERPWD, $this->config['account'].":".$this->config['license']);
+        curl_setopt($curl, CURLOPT_URL, $this->config['url'].$path);
+        curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, $this->config['ssl']);
+        curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 10);
+
+        if($this->config['ssl_ca_path']) {
+            curl_setopt($curl, CURLOPT_CAINFO, $this->config['ssl_ca_path']);
+        }
+
+        if($data) {
+            curl_setopt($curl, CURLOPT_POST, true);
+            curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($data));
+        }
+
+        if($this->config['curl_options']) {
+            foreach($this->config['curl_options'] as $name => $value) {
+                curl_setopt($curl, $name, $value);
+            }
+        }
+
+        $response = curl_exec($curl);
+
+        if($error_number = curl_errno($curl)) {
+            $error_msg = curl_strerror($error_number);
+            throw new AvaException("AddressServiceRest cURL error ({$error_number}): {$error_msg}", AvaException::CURL_ERROR);
+        }
+
+        if(!$response) {
+            throw new AvaException('AddressServiceRest received empty result from API', AvaException::INVALID_API_RESPONSE);
+        }
+
+        curl_close($curl);
+
+        return $response;
+    }
+}

--- a/src/AvaTax/TaxServiceRest.php
+++ b/src/AvaTax/TaxServiceRest.php
@@ -21,7 +21,7 @@
 
 namespace AvaTax;
 
-class TaxServiceRest
+class TaxServiceRest extends RestService
 {
 	static protected $classmap = array(
 		'Address' => 'Address',
@@ -39,88 +39,6 @@ class TaxServiceRest
 		'BaseResult'=>'BaseResult',
 		'TaxOverride'=>'TaxOverride'
 	);
-	protected $config = array();
-
-	/**
-	 * TaxServiceRest constructor.
-	 *
-	 * @param $url string - domain for API endpoint
-	 * @param $account string - API account
-	 * @param $license string - API license
-	 * @param bool $ssl - whether to use SSL connecting to the API (Windows users read below)
-	 * Some Windows users have had trouble with our SSL Certificates. Uncomment the following line to NOT use SSL.
-	 * This is not recommended, see below ($ssl_ca_path) for better alternative*
-	 * @param null $ssl_ca_path - Manually set an SSL path to a cert (Windows users read below)
-	 * $ssl_ca_path: Other Windows users may prefer to download the certificate from our site (detail here: http://developer.avalara.com/api-docs/designing-your-integration/errors-and-outages/ssl-certificates) and manually set the cert path.
-	 * To set the path manually, uncomment the following two lines and ensure you are telling curl where it can find the root certificate. If you choose to manually set the path, make sure you have reenabled cURL by commenting out the line above
-	 * that tells curl to NOT use SSL.
-	 * ex: $ssl_ca_path = "C:/curl/curl-ca-bundle.crt";
-	 *
-	 */
-	public function __construct($url, $account, $license, $ssl = true, $ssl_ca_path = null)
-	{
-		$this->config = array(
-			'url' => $url,
-			'account' => $account,
-			'license' => $license,
-			'ssl' => $ssl,
-			'ssl_ca_path' => $ssl_ca_path
-		);
-	}
-
-	/**
-	 * Process a request to the API
-	 *
-	 * @param $path
-	 * @param null $data
-	 * @return mixed
-	 * @throws AvaException
-	 */
-	private function processRequest($path, $data = null)
-	{
-		if(!$this->config['url'] || !(filter_var($this->config['url'], FILTER_VALIDATE_URL))) {
-			throw new AvaException("A valid service URL is required.", AvaException::MISSING_INFO);
-		}
-
-		if(empty($this->config['account'])) {
-			throw new AvaException("Account number or username is required.", AvaException::MISSING_INFO);
-		}
-
-		if(empty($this->config['license'])) {
-			throw new AvaException("License key or password is required.", AvaException::MISSING_INFO);
-		}
-
-		$curl = curl_init();
-		curl_setopt($curl, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
-		curl_setopt($curl, CURLOPT_USERPWD, $this->config['account'].":".$this->config['license']);
-		curl_setopt($curl, CURLOPT_URL, $this->config['url'].$path);
-		curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-		curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, $this->config['ssl']);
-
-		if($this->config['ssl_ca_path']) {
-			curl_setopt($curl, CURLOPT_CAINFO, $this->config['ssl_ca_path']);
-		}
-
-		if($data) {
-			curl_setopt($curl, CURLOPT_POST, true);
-			curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($data));
-		}
-
-		$response = curl_exec($curl);
-
-		if($error_number = curl_errno($curl)) {
-			$error_msg = curl_strerror($error_number);
-			throw new AvaException("AddressServiceRest cURL error ({$error_number}): {$error_msg}", AvaException::CURL_ERROR);
-		}
-
-		if(!$response) {
-			throw new AvaException('AddressServiceRest received empty result from API', AvaException::INVALID_API_RESPONSE);
-		}
-
-		curl_close($curl);
-
-		return $response;
-	}
 
 	/**
 	 * Voids a document that has already been recorded on the Admin Console.
@@ -161,10 +79,9 @@ class TaxServiceRest
 	/**
 	 * There is no explicit ping function in the REST API, so here's an imitation.
 	 *
-	 * @param string $msg
 	 * @return EstimateTaxResult
 	 */
-	public function ping($msg = "")
+	public function ping()
 	{
 		$request = new EstimateTaxRequest("47.627935","-122.51702","10");
 		return $this->estimateTax($request);

--- a/src/AvaTax/TaxServiceRest.php
+++ b/src/AvaTax/TaxServiceRest.php
@@ -41,128 +41,133 @@ class TaxServiceRest
 	);
 	protected $config = array();
 
-	public function __construct($url, $account, $license)
+	/**
+	 * TaxServiceRest constructor.
+	 *
+	 * @param $url string - domain for API endpoint
+	 * @param $account string - API account
+	 * @param $license string - API license
+	 * @param bool $ssl - whether to use SSL connecting to the API (Windows users read below)
+	 * Some Windows users have had trouble with our SSL Certificates. Uncomment the following line to NOT use SSL.
+	 * This is not recommended, see below ($ssl_ca_path) for better alternative*
+	 * @param null $ssl_ca_path - Manually set an SSL path to a cert (Windows users read below)
+	 * $ssl_ca_path: Other Windows users may prefer to download the certificate from our site (detail here: http://developer.avalara.com/api-docs/designing-your-integration/errors-and-outages/ssl-certificates) and manually set the cert path.
+	 * To set the path manually, uncomment the following two lines and ensure you are telling curl where it can find the root certificate. If you choose to manually set the path, make sure you have reenabled cURL by commenting out the line above
+	 * that tells curl to NOT use SSL.
+	 * ex: $ssl_ca_path = "C:/curl/curl-ca-bundle.crt";
+	 *
+	 */
+	public function __construct($url, $account, $license, $ssl = true, $ssl_ca_path = null)
 	{
 		$this->config = array(
 			'url' => $url,
 			'account' => $account,
-			'license' => $license);
+			'license' => $license,
+			'ssl' => $ssl,
+			'ssl_ca_path' => $ssl_ca_path
+		);
 	}
 
-	//Voids a document that has already been recorded on the Admin Console.
-	public function cancelTax(&$cancelTaxRequest)
+	/**
+	 * Process a request to the API
+	 *
+	 * @param $path
+	 * @param null $data
+	 * @return mixed
+	 * @throws AvaException
+	 */
+	private function processRequest($path, $data = null)
 	{
-		if(!(filter_var($this->config['url'],FILTER_VALIDATE_URL)))			throw new \Exception("A valid service URL is required.");
-		if(empty($this->config['account']))		throw new Exception("Account number or username is required.");
-		if(empty($this->config['license']))		throw new Exception("License key or password is required.");
-
-		$url = $this->config['url']."/1.0/tax/cancel";
-		$curl = curl_init($url);
-		curl_setopt($curl, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
-		curl_setopt($curl, CURLOPT_USERPWD, $this->config['account'].":".$this->config['license']);
-		//Some Windows users have had trouble with our SSL Certificates. Uncomment the following line to NOT use SSL.
-		// *This is not recommended, see below for better alternative*
-		//curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false); 		
-
-		//Other Windows users may prefer to download the certificate from our site (detail here: http://developer.avalara.com/api-docs/designing-your-integration/errors-and-outages/ssl-certificates) and manually set the cert path.
-		//    To set the path manually, uncomment the following two lines and ensure you are telling curl where it can find the root certificate. If you choose to manually set the path, make sure you have reenabled cURL by commenting out the line above 
-		//    that tells curl to NOT use SSL.
-		//$ca = "C:/curl/curl-ca-bundle.crt";
-		//curl_setopt($curl, CURLOPT_CAINFO, $ca);
-
-		curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-		curl_setopt($curl, CURLOPT_POST, true);
-		curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($cancelTaxRequest));
-		$curl_response = curl_exec($curl);
-		curl_close($curl);
-		return CancelTaxResult::parseResult($curl_response);
-	}
-
-	//Calculates tax on a document and/or records that document to the Admin Console.
-	public function getTax(&$getTaxRequest)
-	{
-		if(!(filter_var($this->config['url'],FILTER_VALIDATE_URL)))			throw new \Exception("A valid service URL is required.");
-		if(empty($this->config['account']))		throw new Exception("Account number or username is required.");
-		if(empty($this->config['license']))		throw new Exception("License key or password is required.");
-
-		$url = $this->config['url']."/1.0/tax/get";
-		$curl = curl_init($url);
-		curl_setopt($curl, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
-		curl_setopt($curl, CURLOPT_USERPWD, $this->config['account'].":".$this->config['license']);
-
-		//Some Windows users have had trouble with our SSL Certificates. Uncomment the following line to NOT use SSL.
-		// *This is not recommended, see below for better alternative*
-		//curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
-
-		//Other Windows users may prefer to download the certificate from our site (detail here: http://developer.avalara.com/api-docs/designing-your-integration/errors-and-outages/ssl-certificates) and manually set the cert path.
-		//    To set the path manually, uncomment the following two lines and ensure you are telling curl where it can find the root certificate. If you choose to manually set the path, make sure you have reenabled cURL by commenting out the line above
-		//    that tells curl to NOT use SSL.
-		//$ca = "C:/curl/curl-ca-bundle.crt";
-		//curl_setopt($curl, CURLOPT_CAINFO, $ca);
-
-		curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-		curl_setopt($curl, CURLOPT_POST, true);
-		curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($getTaxRequest));
-		$curl_response = curl_exec($curl);
-
-		curl_close($curl);
-
-		return GetTaxResult::parseResult($curl_response);
-
-	}
-
-	//Estimates a composite tax based on latitude/longitude and total sale amount.
-	public function estimateTax(&$estimateTaxRequest)
-	{
-		if(!(filter_var($this->config['url'],FILTER_VALIDATE_URL))) {
+		if(!$this->config['url'] || !(filter_var($this->config['url'], FILTER_VALIDATE_URL))) {
 			throw new AvaException("A valid service URL is required.", AvaException::MISSING_INFO);
 		}
 
-		if(empty($this->config['account'])){
+		if(empty($this->config['account'])) {
 			throw new AvaException("Account number or username is required.", AvaException::MISSING_INFO);
 		}
 
-		if(empty($this->config['license'])){
+		if(empty($this->config['license'])) {
 			throw new AvaException("License key or password is required.", AvaException::MISSING_INFO);
 		}
 
-		$url = $this->config['url'].'/1.0/tax/'. $estimateTaxRequest->getLatitude().",".$estimateTaxRequest->getLongitude().'/get?saleamount='.$estimateTaxRequest->getSaleAmount();
 		$curl = curl_init();
 		curl_setopt($curl, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
 		curl_setopt($curl, CURLOPT_USERPWD, $this->config['account'].":".$this->config['license']);
-		curl_setopt($curl, CURLOPT_URL, $url);
-		curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
+		curl_setopt($curl, CURLOPT_URL, $this->config['url'].$path);
+		curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+		curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, $this->config['ssl']);
 
-		//Some Windows users have had trouble with our SSL Certificates. Uncomment the following line to NOT use SSL.
-		// *This is not recommended, see below for better alternative*
-		//curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false); 		
+		if($this->config['ssl_ca_path']) {
+			curl_setopt($curl, CURLOPT_CAINFO, $this->config['ssl_ca_path']);
+		}
 
-		//Other Windows users may prefer to download the certificate from our site (detail here: http://developer.avalara.com/api-docs/designing-your-integration/errors-and-outages/ssl-certificates) and manually set the cert path.
-		//    To set the path manually, uncomment the following two lines and ensure you are telling curl where it can find the root certificate. If you choose to manually set the path, make sure you have reenabled cURL by commenting out the line above 
-		//    that tells curl to NOT use SSL.
-		//$ca = "C:/curl/curl-ca-bundle.crt";
-		//curl_setopt($curl, CURLOPT_CAINFO, $ca);
+		if($data) {
+			curl_setopt($curl, CURLOPT_POST, true);
+			curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($data));
+		}
 
-		$curl_response = curl_exec($curl);
+		$response = curl_exec($curl);
 
 		if($error_number = curl_errno($curl)) {
 			$error_msg = curl_strerror($error_number);
 			throw new AvaException("AddressServiceRest cURL error ({$error_number}): {$error_msg}", AvaException::CURL_ERROR);
 		}
 
-		if(!$curl_response) {
+		if(!$response) {
 			throw new AvaException('AddressServiceRest received empty result from API', AvaException::INVALID_API_RESPONSE);
 		}
 
-		return EstimateTaxResult::parseResult($curl_response);
+		curl_close($curl);
+
+		return $response;
 	}
 
-	//There is no explicit ping function in the REST API, so here's an imitation.
+	/**
+	 * Voids a document that has already been recorded on the Admin Console.
+	 *
+	 * @param $cancelTaxRequest
+	 * @return CancelTaxResult
+	 */
+	public function cancelTax(CancelTaxRequest &$cancelTaxRequest)
+	{
+		return CancelTaxResult::parseResult($this->processRequest("/1.0/tax/cancel", $cancelTaxRequest));
+	}
+
+	/**
+	 * Calculates tax on a document and/or records that document to the Admin Console.
+	 *
+	 * @param $getTaxRequest
+	 * @return GetTaxResult
+	 * @throws Exception
+	 * @throws \Exception
+	 */
+	public function getTax(GetTaxRequest &$getTaxRequest)
+	{
+		return GetTaxResult::parseResult($this->processRequest("/1.0/tax/get", $getTaxRequest));
+	}
+
+	/**
+	 * Estimates a composite tax based on latitude/longitude and total sale amount.
+	 *
+	 * @param $estimateTaxRequest EstimateTaxRequest
+	 * @return EstimateTaxResult
+	 * @throws AvaException
+	 */
+	public function estimateTax(EstimateTaxRequest &$estimateTaxRequest)
+	{
+		return EstimateTaxResult::parseResult($this->processRequest('/1.0/tax/'. $estimateTaxRequest->getLatitude().",".$estimateTaxRequest->getLongitude().'/get?saleamount='.$estimateTaxRequest->getSaleAmount()));
+	}
+
+	/**
+	 * There is no explicit ping function in the REST API, so here's an imitation.
+	 *
+	 * @param string $msg
+	 * @return EstimateTaxResult
+	 */
 	public function ping($msg = "")
 	{
 		$request = new EstimateTaxRequest("47.627935","-122.51702","10");
 		return $this->estimateTax($request);
-
 	}
 }
 

--- a/src/AvaTax/TaxServiceRest.php
+++ b/src/AvaTax/TaxServiceRest.php
@@ -16,7 +16,7 @@
  * @author    Avalara
  * @copyright � 2004 - 2011 Avalara, Inc.  All rights reserved.
  * @package   Tax
- * 
+ *
  */
 
 namespace AvaTax;
@@ -44,9 +44,9 @@ class TaxServiceRest
 	public function __construct($url, $account, $license)
 	{
 		$this->config = array(
-		'url' => $url,
-		'account' => $account,
-		'license' => $license);
+			'url' => $url,
+			'account' => $account,
+			'license' => $license);
 	}
 
 	//Voids a document that has already been recorded on the Admin Console.
@@ -55,16 +55,16 @@ class TaxServiceRest
 		if(!(filter_var($this->config['url'],FILTER_VALIDATE_URL)))			throw new \Exception("A valid service URL is required.");
 		if(empty($this->config['account']))		throw new Exception("Account number or username is required.");
 		if(empty($this->config['license']))		throw new Exception("License key or password is required.");
-		
+
 		$url = $this->config['url']."/1.0/tax/cancel";
 		$curl = curl_init($url);
 		curl_setopt($curl, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
 		curl_setopt($curl, CURLOPT_USERPWD, $this->config['account'].":".$this->config['license']);
 		//Some Windows users have had trouble with our SSL Certificates. Uncomment the following line to NOT use SSL.
-        // *This is not recommended, see below for better alternative*
+		// *This is not recommended, see below for better alternative*
 		//curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false); 		
-		
-        //Other Windows users may prefer to download the certificate from our site (detail here: http://developer.avalara.com/api-docs/designing-your-integration/errors-and-outages/ssl-certificates) and manually set the cert path.
+
+		//Other Windows users may prefer to download the certificate from our site (detail here: http://developer.avalara.com/api-docs/designing-your-integration/errors-and-outages/ssl-certificates) and manually set the cert path.
 		//    To set the path manually, uncomment the following two lines and ensure you are telling curl where it can find the root certificate. If you choose to manually set the path, make sure you have reenabled cURL by commenting out the line above 
 		//    that tells curl to NOT use SSL.
 		//$ca = "C:/curl/curl-ca-bundle.crt";
@@ -80,7 +80,7 @@ class TaxServiceRest
 
 	//Calculates tax on a document and/or records that document to the Admin Console.
 	public function getTax(&$getTaxRequest)
-		{
+	{
 		if(!(filter_var($this->config['url'],FILTER_VALIDATE_URL)))			throw new \Exception("A valid service URL is required.");
 		if(empty($this->config['account']))		throw new Exception("Account number or username is required.");
 		if(empty($this->config['license']))		throw new Exception("License key or password is required.");
@@ -91,10 +91,10 @@ class TaxServiceRest
 		curl_setopt($curl, CURLOPT_USERPWD, $this->config['account'].":".$this->config['license']);
 
 		//Some Windows users have had trouble with our SSL Certificates. Uncomment the following line to NOT use SSL.
-        // *This is not recommended, see below for better alternative*
+		// *This is not recommended, see below for better alternative*
 		//curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
 
-        //Other Windows users may prefer to download the certificate from our site (detail here: http://developer.avalara.com/api-docs/designing-your-integration/errors-and-outages/ssl-certificates) and manually set the cert path.
+		//Other Windows users may prefer to download the certificate from our site (detail here: http://developer.avalara.com/api-docs/designing-your-integration/errors-and-outages/ssl-certificates) and manually set the cert path.
 		//    To set the path manually, uncomment the following two lines and ensure you are telling curl where it can find the root certificate. If you choose to manually set the path, make sure you have reenabled cURL by commenting out the line above
 		//    that tells curl to NOT use SSL.
 		//$ca = "C:/curl/curl-ca-bundle.crt";
@@ -109,7 +109,7 @@ class TaxServiceRest
 
 		return GetTaxResult::parseResult($curl_response);
 
-		}
+	}
 
 	//Estimates a composite tax based on latitude/longitude and total sale amount.
 	public function estimateTax(&$estimateTaxRequest)
@@ -134,10 +134,10 @@ class TaxServiceRest
 		curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
 
 		//Some Windows users have had trouble with our SSL Certificates. Uncomment the following line to NOT use SSL.
-        // *This is not recommended, see below for better alternative*
+		// *This is not recommended, see below for better alternative*
 		//curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false); 		
-		
-        //Other Windows users may prefer to download the certificate from our site (detail here: http://developer.avalara.com/api-docs/designing-your-integration/errors-and-outages/ssl-certificates) and manually set the cert path.
+
+		//Other Windows users may prefer to download the certificate from our site (detail here: http://developer.avalara.com/api-docs/designing-your-integration/errors-and-outages/ssl-certificates) and manually set the cert path.
 		//    To set the path manually, uncomment the following two lines and ensure you are telling curl where it can find the root certificate. If you choose to manually set the path, make sure you have reenabled cURL by commenting out the line above 
 		//    that tells curl to NOT use SSL.
 		//$ca = "C:/curl/curl-ca-bundle.crt";
@@ -156,13 +156,13 @@ class TaxServiceRest
 
 		return EstimateTaxResult::parseResult($curl_response);
 	}
-	
+
 	//There is no explicit ping function in the REST API, so here's an imitation.
 	public function ping($msg = "")
 	{
 		$request = new EstimateTaxRequest("47.627935","-122.51702","10");
 		return $this->estimateTax($request);
-		
+
 	}
 }
 

--- a/src/AvaTax/ValidateResult.php
+++ b/src/AvaTax/ValidateResult.php
@@ -2,9 +2,9 @@
 /**
  * ValidateResult.class.php
  */
- 
+
 /**
- * Contains an array of {@link ValidAddress} objects returned by {@link AddressServiceSoap#validate} 
+ * Contains an array of {@link ValidAddress} objects returned by {@link AddressServiceSoap#validate}
  *
  * <pre>
  *  $port = new AddressServiceSoap();
@@ -21,9 +21,9 @@
  *  print("Number of addresses returned is ". sizeoof($addresses));
  *
  * </pre>
- * 
+ *
  * @see ValidAddress
- * 
+ *
  * @author    Avalara
  * @copyright � 2004 - 2011 Avalara, Inc.  All rights reserved.
  * @package   Address
@@ -33,49 +33,60 @@ namespace AvaTax;
 
 class ValidateResult extends BaseResult implements JsonSerializable
 {
-/**
- * Array of matching {@link ValidAddress}'s.
- * @var array
- */
-	private $ValidAddress;
-	private $ResultCode = 'Success';
-	private $Messages = array();
+    /**
+     * Array of matching {@link ValidAddress}'s.
+     * @var array
+     */
+    private $ValidAddress;
+    private $ResultCode = 'Success';
+    private $Messages = array();
 
-	public function __construct($resultCode , $validaddress , $messages)
-	{
-		$this->ResultCode = $resultCode;
-		$this->ValidAddress = $validaddress;
-		$this->Messages = $messages;
-	}
-	
-	
-		//Helper function to decode result objects from Json responses to specific objects.
-	public static function parseResult($jsonString)
-	{
-		$object = json_decode($jsonString);
-		$validaddress = new ValidAddress();
-		$messages = array();
-		$resultcode = null;
-		
-		if( property_exists($object,"ResultCode")) $resultcode = $object->ResultCode; 		
-		if(property_exists($object, "Address"))
-			$validaddress = ValidAddress::parseAddress(json_encode($object->Address));	
-		if(property_exists($object, "Messages"))
-			$messages = Message::parseMessages("{\"Messages\": ".json_encode($object->Messages)."}");
-		
-		return new self( $resultcode , $validaddress , $messages );	
-	}
-	public function jsonSerialize(){
-		return array(
-			'ValidAddress' => $this->getValidAddress(),
-			'ResultCode' => $this->getResultCode(),
-			'Messages' => $this->getMessages()
-		);
-	}
+    public function __construct($resultCode , $validaddress , $messages)
+    {
+        $this->ResultCode = $resultCode;
+        $this->ValidAddress = $validaddress;
+        $this->Messages = $messages;
+    }
 
-	public function getValidAddress() { return $this->ValidAddress; }
-	public function getResultCode() { return $this->ResultCode; }
-	public function getMessages() { return $this->Messages; }
+
+    //Helper function to decode result objects from Json responses to specific objects.
+    public static function parseResult($jsonString)
+    {
+        $object = json_decode($jsonString);
+
+        if(json_last_error() !== JSON_ERROR_NONE) {
+            throw new AvaException("ValidateResult failed to parse JSON", AvaException::INVALID_API_RESPONSE);
+        }
+
+        $validaddress = new ValidAddress();
+        $messages = array();
+        $resultcode = null;
+
+        if( property_exists($object,"ResultCode")) {
+            $resultcode = $object->ResultCode;
+        }
+
+        if(property_exists($object, "Address")) {
+            $validaddress = ValidAddress::parseAddress(json_encode($object->Address));
+        }
+
+        if(property_exists($object, "Messages")) {
+            $messages = Message::parseMessages("{\"Messages\": ".json_encode($object->Messages)."}");
+        }
+
+        return new self( $resultcode , $validaddress , $messages );
+    }
+    public function jsonSerialize(){
+        return array(
+            'ValidAddress' => $this->getValidAddress(),
+            'ResultCode' => $this->getResultCode(),
+            'Messages' => $this->getMessages()
+        );
+    }
+
+    public function getValidAddress() { return $this->ValidAddress; }
+    public function getResultCode() { return $this->ResultCode; }
+    public function getMessages() { return $this->Messages; }
 
 }
 

--- a/src/AvaTax/ValidateResult.php
+++ b/src/AvaTax/ValidateResult.php
@@ -31,15 +31,13 @@
 
 namespace AvaTax;
 
-class ValidateResult extends BaseResult implements JsonSerializable
+class ValidateResult extends AvaResult implements JsonSerializable
 {
     /**
      * Array of matching {@link ValidAddress}'s.
-     * @var array
+     * @var array|ValidAddress[]
      */
     private $ValidAddress;
-    private $ResultCode = 'Success';
-    private $Messages = array();
 
     public function __construct($resultCode , $validaddress , $messages)
     {
@@ -48,21 +46,22 @@ class ValidateResult extends BaseResult implements JsonSerializable
         $this->Messages = $messages;
     }
 
-
-    //Helper function to decode result objects from Json responses to specific objects.
+    /**
+     * Helper function to decode result objects from Json responses to specific objects.
+     *
+     * @param $jsonString
+     * @return ValidateResult
+     * @throws AvaException
+     */
     public static function parseResult($jsonString)
     {
-        $object = json_decode($jsonString);
-
-        if(json_last_error() !== JSON_ERROR_NONE) {
-            throw new AvaException("ValidateResult failed to parse JSON", AvaException::INVALID_API_RESPONSE);
-        }
+        $object = self::jsonDecode($jsonString);
 
         $validaddress = new ValidAddress();
         $messages = array();
         $resultcode = null;
 
-        if( property_exists($object,"ResultCode")) {
+        if( property_exists($object, "ResultCode")) {
             $resultcode = $object->ResultCode;
         }
 
@@ -76,6 +75,7 @@ class ValidateResult extends BaseResult implements JsonSerializable
 
         return new self( $resultcode , $validaddress , $messages );
     }
+
     public function jsonSerialize(){
         return array(
             'ValidAddress' => $this->getValidAddress(),
@@ -85,9 +85,6 @@ class ValidateResult extends BaseResult implements JsonSerializable
     }
 
     public function getValidAddress() { return $this->ValidAddress; }
-    public function getResultCode() { return $this->ResultCode; }
-    public function getMessages() { return $this->Messages; }
-
 }
 
 ?>


### PR DESCRIPTION
Fixes #31 
Closes #17 
Closes #32 

Needed these fixes. We are implementing Avalara on our website and if the request to the Avalara API fails we need to get an exception thrown instead of a fatal/warning occurring (for example #31 happened because of this). This allows us to program for these situations and handle accordingly (for example, if there is an error connecting then log it to the system log and notify a developer).

I also included a bunch of PHPDoc and other fixes to code I saw issues with. I also made it so all cURL requests go through one function to clean up the Rest classes.

Also both AddressServiceRest and TaxServiceRest both now accept two extra (non required) parameters for SSL. This way the user doesn't have to change the actual source files to use these fixes (bad practice if you are using composer)

None of these changes should break anyone's code already out there. I made sure to leave it compatible with PHP >= 5.3. The major addition is using Exceptions more when a request to the API is being made for better debugging and error handling.
