### PR TITLE
Making ValidAddress flexible when PostNet not returned

### DIFF
--- a/src/AvaTax/ValidAddress.php
+++ b/src/AvaTax/ValidAddress.php
@@ -78,7 +78,7 @@ class ValidAddress
 			isset($object->County) ? $object->County : null,
 			$object->FipsCode,
 			isset($object->CarrierRoute) ? $object->CarrierRoute : null,
-			$object->PostNet,
+			isset($object->PostNet) ? $object->PostNet : null,
 			$object->AddressType);
 	}
 

--- a/src/AvaTax/ValidAddress.php
+++ b/src/AvaTax/ValidAddress.php
@@ -79,7 +79,7 @@ class ValidAddress
 			$object->FipsCode,
 			isset($object->CarrierRoute) ? $object->CarrierRoute : null,
 			isset($object->PostNet) ? $object->PostNet : null,
-			$object->AddressType);
+			isset($object->AddressType) ? $object->AddressType : null);
 	}
 
 


### PR DESCRIPTION
Similar to https://github.com/avadev/AvaTax-Calc-REST-PHP/pull/13 - making the `PostNet` field optional to avoid the following error: `ErrorException: Undefined property: stdClass::$PostNet in .../src/AvaTax/ValidAddress.php:81`